### PR TITLE
Cleaner HON Build code with faster computation

### DIFF
--- a/pyHON/BuildNetwork.py
+++ b/pyHON/BuildNetwork.py
@@ -20,46 +20,29 @@ Verbose = True
 def Initialize():
     Graph = defaultdict(dict)
 
+def longestSuffix(s, rules_keys):
+    ## returns the longest suffix of tuple 's'
+    ## that exist in list of tuple rules_keys
+    ## if s in rules_keys then returns s
+    ss = s
+    while len(ss)>1:
+        if ss in rules_keys:
+            return ss
+        else:
+            ss = ss[1:]
+    return ss
 
 def BuildNetwork(Rules):
     VPrint('Building network')
     Initialize()
-    SortedSource = sorted(Rules, key=lambda x: len(x))
-    for source in SortedSource:
-        for target in Rules[source]:
-            Graph[source][(target,)] = Rules[source][target]
-            # following operations are destructive to Rules
-            if len(source) > 1:
-                Rewire(source, (target,))
-    RewireTails()
+    for s in Rules.keys():
+        for t in Rules[s]:
+            ## adding link s -> s*t where 
+            ## and s* is the longest suffix of s 
+            ## such that s*t is an existing rule
+            nt = longestSuffix(s+(t,), Rules.keys())
+            Graph[s][nt] = Rules[s][t]
     return Graph
-
-def Rewire(source, target):
-    PrevSource = source[:-1]
-    PrevTarget = (source[-1],)
-    if not PrevSource in Graph or not source in Graph[PrevSource]:
-        Graph[PrevSource][source] = Graph[PrevSource][PrevTarget]
-        del(Graph[PrevSource][PrevTarget])
-
-def RewireTails():
-    ToAdd = []
-    ToRemove = []
-    for source in Graph:
-        for target in Graph[source]:
-            if len(target) == 1:
-                NewTarget = source + target
-                while len(NewTarget) > 1:
-                    if NewTarget in Graph:
-                        ToAdd.append((source, NewTarget, Graph[source][target]))
-                        ToRemove.append((source, target))
-                        break
-                    else:
-                        NewTarget = NewTarget[1:]
-    for (source, target, weight) in ToAdd:
-        Graph[source][target] = weight
-    for (source, target) in ToRemove:
-        del(Graph[source][target])
-
 
 ###########################################
 # Auxiliary functions


### PR DESCRIPTION
Hi all!

After doing some tests, I seems to me that there is a cleaner way of defining the HON network (or rather the Edge set) from a set of Rules.
Let S=s1s2s3... be a rule and t a symbol in the input sequence such that Rules[S][t] > 0,
this will correspond in HON to a directed edge S -> S't where S't is the concatenation of S' and t
here S'=s3s4... is the longest suffix of S such that S't is an existing rule.

For example if S=abc and Rules[abc][t] > 0 then there will be an edge abc -> bct if 'abct' was not detected as a rule while 'bct' was. 
If no extension of 't' was detected as a rule, we would simply have abc -> t (since the longest suffix S' is here the empty string). 

From this definition we can rewrite the code of "BuildNetwork.py" without using any rewiring of edges. Using real datasets I got the same HON with the proposed changes. Moreover my method seems to be faster when there are a lot of edges to add (or rewiring to do in the current version). 

I hope I didn't miss something. I tested both approaches on different real world sequences and the new definition of the edge set is comprehensive IMO  but still ...